### PR TITLE
feat(marker): convert to callExpression

### DIFF
--- a/src/marker.js
+++ b/src/marker.js
@@ -26,12 +26,17 @@ export function isInstrumented(pathOrNode) {
  * Create a non-instrumentable marker.
  * @param  {Object} state Babel state object.
  * @param  {Object} path  Babel path object.
+ * @param  {Object} node  Babel path's node object.
  * @return {Node}         Marker.
  */
-export function createMarker(state, {loc, tags}) {
+export function createMarker(state, {loc, tags}, node) {
   const {locations, variable} = getCoverageMeta(state);
   const id = locations.length;
-  const marker = types.callExpression(variable, [types.numericLiteral(id)]);
+  const args = [types.numericLiteral(id)];
+  if (node) {
+    args.push(node);
+  }
+  const marker = types.callExpression(variable, args);
   locations.push({id, loc, tags, count: 0});
   return markAsInstrumented(marker);
 }

--- a/src/templates/prelude.js
+++ b/src/templates/prelude.js
@@ -7,8 +7,9 @@ const VARIABLE = (context => {
     path: FILEPATH,
     locations
   };
-  return index => {
+  return (index, value) => {
     locations[index].count += 1;
+    return value;
   };
 })(
   typeof global === 'undefined' ? window : global

--- a/src/visitors.js
+++ b/src/visitors.js
@@ -28,11 +28,11 @@ function safeguardVisitors(visitors) {
 export default safeguardVisitors({
 
   // Source: 'ngInject';
-  // Instrumented: 'ngInject'; ++count;
+  // Instrumented: 'ngInject'; _increment(0);
   Directive(path, state) {
     const loc = path.node.loc;
     const marker = createMarker(state, {loc, tags: ['statement', 'directive']});
-    path.parentPath.unshiftContainer('body', markAsInstrumented(
+    path.insertAfter(markAsInstrumented(
       t.expressionStatement(marker)
     ));
   },
@@ -190,9 +190,9 @@ export default safeguardVisitors({
   },
 
   // Source: {['a'](){}}
-  // Instrumented: {[(++count, 'a')]: (++count, function a() { ++count; }})
+  // Instrumented: {[_increment(0, 'a')]: _increment(1, function a() { _increment(2); })}
   // Source: {a(){}}
-  // Instrumented: {a: (++count, function a() { ++count; }})
+  // Instrumented: {[_increment(3, 'a')]() { _increment(2); }}
   ObjectMethod(path, state) {
     instrumentBlock('body', path.get('body'), state, ['function']);
     instrumentObjectProperty(path, state);


### PR DESCRIPTION
Now marker is a pure callExpression (sometimes wrapped in a expressionStatement) with node passed as second argument.
